### PR TITLE
removed wildcard import warning from detekt

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -108,7 +108,7 @@ complexity:
     excludeStringsWithLessThan5Characters: true
     ignoreStringsRegex: '$^'
   TooManyFunctions:
-    active: 
+    active:
     thresholdInFiles: 11
     thresholdInClasses: 11
     thresholdInInterfaces: 11
@@ -259,8 +259,8 @@ formatting:
     active: true
     autoCorrect: true
   NoWildcardImports:
-    active: true
-    autoCorrect: true
+    active: false
+    autoCorrect: false
   PackageName:
     active: true
     autoCorrect: true
@@ -519,5 +519,5 @@ style:
   VarCouldBeVal:
     active: false
   WildcardImport:
-    active: true
+    active: false
     excludeImports: 'java.util.*,kotlinx.android.synthetic.*'


### PR DESCRIPTION
This removes the warning for wild card imports